### PR TITLE
chore: Bumps source commit and go version

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -14,9 +14,9 @@ parts:
     plugin: go
     source: https://github.com/omec-project/nssf.git
     source-type: git
-    source-commit: 4e5aef39c256208ad0f830be56da7f4bcc516163
+    source-commit: 349dd6ce2bcfc18a340a5c0973498bf63ca1b720
     build-snaps:
-      - go/1.18/stable
+      - go/1.21/stable
     stage-packages:
       - libc6_libs
     organize:


### PR DESCRIPTION
# Description

As we bumped to go version to 1.21 in the upstream project and made many dependency updates there, we bump the commit to the latest one available in the upstream project that contains all those changes.

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
