### PR TITLE
chore: Bump NSSF commit ID to get latest changes

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -14,7 +14,7 @@ parts:
     plugin: go
     source: https://github.com/omec-project/nssf.git
     source-type: git
-    source-commit: 349dd6ce2bcfc18a340a5c0973498bf63ca1b720
+    source-commit: 8196d18f4d381e61753548ab38fad4f97b33ee60
     build-snaps:
       - go/1.21/stable
     stage-packages:


### PR DESCRIPTION
# Description

Bumps the commit ID of the upstream project to fetch latest changes, including many dependencies update for security and a fix for the 100% CPU usage when the network is not configured.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
