### PR TITLE
chore: workflows trigger only on PR events, and not on push

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
       - v**
+  push:
+    branches:
+      - main
+      - v**
   schedule:
     - cron: '0 0 * * 0'
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -2,9 +2,9 @@ name: Main
 
 on:
   pull_request:
+    types: [edited, opened, reopened, synchronize]
     branches:
       - main
-  push:
   schedule:
     - cron: '0 0 * * 0'
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,6 +5,7 @@ on:
     types: [edited, opened, reopened, synchronize]
     branches:
       - main
+      - v**
   schedule:
     - cron: '0 0 * * 0'
 


### PR DESCRIPTION
# Description

This change makes the CI trigger only on PR events, and not on push. This will prevent duplicate runs of CI jobs. It will also prevent the `scan-rock` failing when run on push.

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
